### PR TITLE
Fix Filecrypt.Cc

### DIFF
--- a/plugins/crypter/FilecryptCc.py
+++ b/plugins/crypter/FilecryptCc.py
@@ -17,7 +17,7 @@ from ..internal.Crypter import Crypter
 class FilecryptCc(Crypter):
     __name__ = "FilecryptCc"
     __type__ = "crypter"
-    __version__ = "0.29"
+    __version__ = "0.30"
     __status__ = "testing"
 
     __pattern__ = r'https?://(?:www\.)?filecrypt\.cc/Container/\w+'
@@ -77,7 +77,7 @@ class FilecryptCc(Crypter):
             self.site_with_links = self.site_with_links + self.load(i)
 
     def handle_password_protection(self):
-        if '<input type="password" name="password"' not in self.data:
+        if '<div class="input">\n                    <input type="password" name="password" id="p4assw0rt"' not in self.data:
             return
 
         self.log_info(_("Folder is password protected"))


### PR DESCRIPTION
By default Filecrypt comments the Password prompt out.

`<!--<input type="password" name="password" id="p4assw0rt"`

So the condition `if '<input type="password" name="password"' not in self.data:` will always be false.

My change fixes this error.